### PR TITLE
Add a new ring implementation that works with Sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
 Ringman
 =======
 
-This is a consistent hash ring implementation backed by [our fork of
-Hashicorp's Memberlist library](https://github.com/Nitro/memberlist) and the
+This is a consistent hash ring implementation backed by either [our fork of
+Hashicorp's Memberlist library](https://github.com/Nitro/memberlist), or
+[Sidecar service discovery platform](https://github.com/Nitro/sidecar), and the
 [hashring](https://github.com/serialx/hashring) library.
 
 It sets up an automatic consistent hash ring across multiple nodes. The nodes
-are discovered and health validated over Memberlist's implementation of the
-SWIM gossip protocol. It manages adding and removing nodes from the ring based
-on events from Memberlist.
+are discovered and health validated either over Memberlist's implementation of
+the SWIM gossip protocol or via Sidecar. It manages adding and removing nodes
+from the ring based on events from Memberlist or Sidecar.
 
 In addition, the package provides some HTTP handlers and a Mux that can be
 mounted anywhere in your application if you want to expose the hashring.
 
+Memberlist Ring
+---------------
+
 If you just want to get information from the ring you can query it in your code
 directly like:
 
-```
+```go
 ring, err := ringman.NewDefaultMemberlistRing([]string{127.0.0.1}, "8000")
 if err != nil {
     log.Fatalf("Unble to establish memberlist ring: %s", err)
@@ -80,5 +84,22 @@ Which returns output like:
   "Node": "ubuntu",
   "Key": "somekey"
 }
+```
+
+Sidecar Ring
+------------
+
+An alternate implementation backed by New Relic/Nitro's [Sidecar](https://github.com/Nitro/sidecar)
+is available as well. It assumes it will be subscribed to incoming Sidecar events on
+the listener port. See the Sidecar [README](https://github.com/Nitro/sidecar) for how
+to set that up. Once that is established, you can do the following:
+
+```go
+ring, err := ringman.NewSidecarRing("http://localhost:7777/api/state.json")
+if err != nil {
+    log.Fatalf("Unble to establish sidecar ring: %s", err)
+}
+
+println(ring.Manager.GetNode("mykey"))
 ```
 

--- a/delegate.go
+++ b/delegate.go
@@ -12,6 +12,10 @@ type NodeMetadata struct {
 	ServicePort string
 }
 
+// Delegate is a Memberlist delegate that is responsible for handling
+// integration between the hash ring and Memberlist messages. See
+// the Memberlist documentation for detailed explanations of the
+// callback methods.
 type Delegate struct {
 	RingMan      *HashRingManager
 	nodeMetadata *NodeMetadata

--- a/hashring.go
+++ b/hashring.go
@@ -43,7 +43,7 @@ type RingReply struct {
 	Nodes []string
 }
 
-type RingImplementation interface {
+type Ring interface {
 	HttpMux() *http.ServeMux
 	Shutdown()
 }

--- a/hashring.go
+++ b/hashring.go
@@ -2,6 +2,7 @@ package ringman
 
 import (
 	"errors"
+	"net/http"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -40,6 +41,10 @@ type RingCommand struct {
 type RingReply struct {
 	Error error
 	Nodes []string
+}
+
+type RingImplementation interface {
+	HttpMux() *http.ServeMux
 }
 
 // NewHashRingManager returns a properly configured HashRingManager. It accepts

--- a/hashring.go
+++ b/hashring.go
@@ -46,6 +46,7 @@ type RingReply struct {
 type Ring interface {
 	HttpMux() *http.ServeMux
 	Shutdown()
+	Manager() *HashRingManager
 }
 
 // NewHashRingManager returns a properly configured HashRingManager. It accepts

--- a/hashring.go
+++ b/hashring.go
@@ -45,6 +45,7 @@ type RingReply struct {
 
 type RingImplementation interface {
 	HttpMux() *http.ServeMux
+	Shutdown()
 }
 
 // NewHashRingManager returns a properly configured HashRingManager. It accepts

--- a/hashring.go
+++ b/hashring.go
@@ -1,3 +1,8 @@
+// Ringman implements a consistent hash ring for service sharding,
+// backed either by Hashicorp's Memberlist directly, or by
+// Sidecar service discovery platform. It maintains state about
+// which nodes are available in a cluster and can be queried for
+// a node to match a hash key.
 package ringman
 
 import (

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -110,3 +110,13 @@ func Test_Commands(t *testing.T) {
 		})
 	})
 }
+
+func Test_RingImplementation(t *testing.T) {
+	Convey("SidecarRing and MemberlistRing implement RingImplementation", t, func() {
+		var ring RingImplementation
+
+		So(func() { ring = &MemberlistRing{} }, ShouldNotPanic)
+		So(func() { ring = &SidecarRing{} }, ShouldNotPanic)
+	})
+
+}

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -111,9 +111,9 @@ func Test_Commands(t *testing.T) {
 	})
 }
 
-func Test_RingImplementation(t *testing.T) {
-	Convey("SidecarRing and MemberlistRing implement RingImplementation", t, func() {
-		var ring RingImplementation
+func Test_Ring(t *testing.T) {
+	Convey("SidecarRing and MemberlistRing implement Ring", t, func() {
+		var ring Ring
 
 		So(func() { ring = &MemberlistRing{} }, ShouldNotPanic)
 		So(func() { ring = &SidecarRing{} }, ShouldNotPanic)

--- a/memberlist.go
+++ b/memberlist.go
@@ -17,7 +17,7 @@ import (
 // will need to have some seeds provided that allow them to find each other.
 type MemberlistRing struct {
 	Memberlist    *memberlist.Memberlist
-	Manager       *HashRingManager
+	manager       *HashRingManager
 	managerLooper director.Looper
 }
 
@@ -87,7 +87,7 @@ func NewMemberlistRing(mlConfig *memberlist.Config, clusterSeeds []string, port 
 
 	return &MemberlistRing{
 		Memberlist:    list,
-		Manager:       ringMgr,
+		manager:       ringMgr,
 		managerLooper: looper,
 	}, nil
 }
@@ -124,7 +124,7 @@ func (r *MemberlistRing) HttpGetNodeHandler(w http.ResponseWriter, req *http.Req
 		return
 	}
 
-	node, _ := r.Manager.GetNode(key)
+	node, _ := r.manager.GetNode(key)
 
 	respObj := struct {
 		Node string
@@ -149,6 +149,10 @@ func (r *MemberlistRing) HttpMux() *http.ServeMux {
 	return mux
 }
 
+func (r *MemberlistRing) Manager() *HashRingManager {
+	return r.manager
+}
+
 // Shutdown shuts down the memberlist node and stops the HashRingManager
 func (r *MemberlistRing) Shutdown() {
 	err := r.Memberlist.Leave(2 * time.Second) // 2 second timeout
@@ -161,7 +165,7 @@ func (r *MemberlistRing) Shutdown() {
 		log.Debugf("Failed to shutdown Memberlist: %s", err)
 	}
 
-	r.Manager.Stop()
+	r.manager.Stop()
 
 	r.managerLooper.Quit()
 }

--- a/memberlist.go
+++ b/memberlist.go
@@ -11,6 +11,10 @@ import (
 	"github.com/relistan/go-director"
 )
 
+// A MemberlistRing is a ring backed by Hashicorp's Memberlist directly. It
+// exchanges gossip messages directly between instances of this service and
+// requires some open ports for them to communicate with each other. The nodes
+// will need to have some seeds provided that allow them to find each other.
 type MemberlistRing struct {
 	Memberlist    *memberlist.Memberlist
 	Manager       *HashRingManager

--- a/memberlist.go
+++ b/memberlist.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/Nitro/memberlist"
-	log "github.com/sirupsen/logrus"
 	"github.com/relistan/go-director"
+	log "github.com/sirupsen/logrus"
 )
 
 // A MemberlistRing is a ring backed by Hashicorp's Memberlist directly. It

--- a/memberlist_test.go
+++ b/memberlist_test.go
@@ -23,9 +23,9 @@ func Test_NewMemberlistRing(t *testing.T) {
 		ourAddr := mlistRing.Memberlist.LocalNode().Addr.String()
 		Convey("returns a properly configured MemberlistRing", func() {
 			So(mlistRing.Memberlist, ShouldNotBeNil)
-			So(mlistRing.Manager, ShouldNotBeNil)
+			So(mlistRing.manager, ShouldNotBeNil)
 
-			node, err := mlistRing.Manager.GetNode("beowulf")
+			node, err := mlistRing.manager.GetNode("beowulf")
 			So(err, ShouldBeNil)
 			So(node, ShouldEqual, ourAddr+":8000")
 
@@ -41,8 +41,8 @@ func Test_MemberListRingShutdown(t *testing.T) {
 
 		mlistRing.Shutdown()
 
-		So(mlistRing.Manager.Ping(), ShouldBeFalse)
-		So(mlistRing.Manager.cmdChan, ShouldBeNil)
+		So(mlistRing.manager.Ping(), ShouldBeFalse)
+		So(mlistRing.manager.cmdChan, ShouldBeNil)
 	})
 }
 

--- a/sidecar.go
+++ b/sidecar.go
@@ -35,7 +35,7 @@ type SidecarRing struct {
 
 // NewSidecarRing returns a properly configured SidecarRing that will filter
 // incoming changes by the service name provided and will only watch the
-// ServicePort number passed in. If the SidecarUrl is not empty string, then
+// ServicePort number passed in. If the SidecarUrl is not empty string,
 // then we will call that address to get initial state on bootstrap.
 func NewSidecarRing(sidecarUrl string, svcName string, svcPort int64) (*SidecarRing, error) {
 	ringMgr := NewHashRingManager([]string{})

--- a/sidecar.go
+++ b/sidecar.go
@@ -26,7 +26,7 @@ const (
 type SidecarRing struct {
 	Manager       *HashRingManager
 	managerLooper director.Looper
-	sidecarUrl   string
+	sidecarUrl    string
 	svcName       string
 	svcPort       int64
 	rcvr          *receiver.Receiver
@@ -45,7 +45,7 @@ func NewSidecarRing(sidecarUrl string, svcName string, svcPort int64) (*SidecarR
 	scRing := &SidecarRing{
 		Manager:       ringMgr,
 		managerLooper: looper,
-		sidecarUrl:   sidecarUrl,
+		sidecarUrl:    sidecarUrl,
 		svcName:       svcName,
 		svcPort:       svcPort,
 	}
@@ -86,14 +86,14 @@ func (r *SidecarRing) onUpdate(state *catalog.ServicesState) {
 	})
 
 	// Was it it in the new group and not in the old one? Add it.
-	for name, _ := range newNodes {
+	for name := range newNodes {
 		if _, ok := r.nodes[name]; !ok {
 			r.Manager.AddNode(name)
 		}
 	}
 
 	// In the old group but not in the new one? Remove it.
-	for name, _ := range r.nodes {
+	for name := range r.nodes {
 		if _, ok := newNodes[name]; !ok {
 			r.Manager.RemoveNode(name)
 		}

--- a/sidecar.go
+++ b/sidecar.go
@@ -1,0 +1,188 @@
+package ringman
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Nitro/sidecar/catalog"
+	"github.com/Nitro/sidecar/receiver"
+	"github.com/Nitro/sidecar/service"
+	"github.com/relistan/go-director"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	DefaultReceiverCapacity = 50
+)
+
+// A SidecarRing is a ring backed by service discovery from Sidecar
+// https://github.com/Nitro/sidecar . Sidecar itself uses Memberlist under
+// the covers, but layers a lot more on top. Sidecar takes care of all
+// the work of managing and bootstrapping the cluster so we don't need
+// to know anything about cluster seeds. This service is expected to
+// subscribe to Sidecar events, however, and uses a Sidecar Receiver to
+// process them.
+type SidecarRing struct {
+	Manager       *HashRingManager
+	managerLooper director.Looper
+	sidecarAddr   string
+	svcName       string
+	svcPort       int64
+	rcvr          *receiver.Receiver
+	nodes         map[string]struct{} // Tracking which nodes we already know about
+}
+
+// NewSidecarRing returns a properly configured SidecarRing that will filter
+// incoming changes by the service name provided and will only watch the
+// ServicePort number passed in.
+func NewSidecarRing(sidecarAddr string, svcName string, svcPort int64) *SidecarRing {
+	ringMgr := NewHashRingManager([]string{})
+	looper := director.NewFreeLooper(director.FOREVER, nil)
+	go ringMgr.Run(looper)
+
+	scRing := &SidecarRing{
+		Manager:       ringMgr,
+		managerLooper: looper,
+		sidecarAddr:   sidecarAddr,
+		svcName:       svcName,
+		svcPort:       svcPort,
+	}
+
+	// Set up the receiver for incoming requests
+	rcvr := receiver.NewReceiver(DefaultReceiverCapacity, scRing.onUpdate)
+	// Subscribe to only the service requested
+	rcvr.Subscribe(svcName)
+	scRing.rcvr = rcvr
+
+	go rcvr.ProcessUpdates()
+
+	return scRing
+}
+
+// onUpdate takes care of incoming updates from the receiver
+func (r *SidecarRing) onUpdate(state *catalog.ServicesState) {
+	newNodes := make(map[string]struct{}, len(r.nodes)+5) // Likely to be similar length
+
+	state.EachService(func(hostname *string, serviceId *string, svc *service.Service) {
+		if svc.Name == r.svcName {
+			key, err := r.keyForService(svc)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			newNodes[key] = struct{}{}
+		}
+	})
+
+	// Was it it in the new group and not in the old one? Add it.
+	for name, _ := range newNodes {
+		if _, ok := r.nodes[name]; !ok {
+			r.Manager.AddNode(name)
+		}
+	}
+
+	// In the old group but not in the new one? Remove it.
+	for name, _ := range r.nodes {
+		if _, ok := newNodes[name]; !ok {
+			r.Manager.RemoveNode(name)
+		}
+	}
+
+	// Overwrite the old set
+	r.nodes = newNodes
+}
+
+// keyForService takes a service and returns the key we use to store it in the
+// hashring. Currently based on the IP address and service port.
+func (r *SidecarRing) keyForService(svc *service.Service) (string, error) {
+	var matched *service.Port
+	for _, port := range svc.Ports {
+		if port.ServicePort == r.svcPort {
+			matched = &port
+			break
+		}
+	}
+
+	if matched == nil {
+		return "", fmt.Errorf(
+			"Can't match service port %d for incoming service %s!",
+			r.svcPort, svc.ID,
+		)
+	}
+
+	var key string
+	if matched.IP == "" {
+		key = svc.Hostname
+	} else {
+		key = matched.IP
+	}
+
+	return fmt.Sprintf("%s:%d", key, matched.Port), nil
+}
+
+// HttpListNodesHandler is an http.Handler that will return a JSON-encoded list of
+// the Sidecar nodes in the current ring.
+func (r *SidecarRing) HttpListNodesHandler(w http.ResponseWriter, req *http.Request) {
+	defer req.Body.Close()
+
+	jsonBytes, err := json.MarshalIndent(&r.nodes, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	w.Write(jsonBytes)
+}
+
+// HttpGetNodeHandler is an http.Handler that will return an object containing the
+// node that currently owns a specific key.
+func (r *SidecarRing) HttpGetNodeHandler(w http.ResponseWriter, req *http.Request) {
+	defer req.Body.Close()
+
+	key := req.FormValue("key")
+	if key == "" {
+		http.Error(w, `{"status": "error", "message": "Invalid key"}`, 404)
+		return
+	}
+
+	if r == nil {
+		http.Error(w, `{"status": "error", "message": "SidecarRing was nil"}`, 500)
+		return
+	}
+
+	node, _ := r.Manager.GetNode(key)
+
+	respObj := struct {
+		Node string
+		Key  string
+	}{node, key}
+
+	jsonBytes, err := json.MarshalIndent(respObj, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+	}
+
+	w.Write(jsonBytes)
+}
+
+// HttpMux returns an http.ServeMux configured to run the HTTP handlers on the
+// SidecarRing. You can either use this one, or mount the handlers on a mux of your
+// own choosing (e.g. Gorilla mux or httprouter)
+func (r *SidecarRing) HttpMux() *http.ServeMux {
+	updateHandler := func(w http.ResponseWriter, req *http.Request) {
+		receiver.UpdateHandler(w, req, r.rcvr)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/nodes/get", r.HttpGetNodeHandler)
+	mux.HandleFunc("/nodes", r.HttpListNodesHandler)
+	mux.HandleFunc("/update", updateHandler)
+	return mux
+}
+
+// Shutdown stops the Receiver and the HashringManager
+func (r *SidecarRing) Shutdown() {
+	r.rcvr.Looper.Quit()
+	r.managerLooper.Quit()
+}

--- a/sidecar.go
+++ b/sidecar.go
@@ -75,7 +75,7 @@ func (r *SidecarRing) onUpdate(state *catalog.ServicesState) {
 	newNodes := make(map[string]struct{}, len(r.nodes)+5) // Likely to be similar length
 
 	state.EachService(func(hostname *string, serviceId *string, svc *service.Service) {
-		if svc.Name == r.svcName {
+		if svc.Name == r.svcName && svc.IsAlive() { // Only get ALIVE nodes...
 			key, err := r.keyForService(svc)
 			if err != nil {
 				log.Error(err)

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -38,10 +38,28 @@ func Test_NewSidecarRing(t *testing.T) {
 				},
 			)
 
-			NewSidecarRing("http://localhost:7777/api/state.json", "some-svc", 9999)
+			ring, err := NewSidecarRing("http://localhost:7777/api/state.json", "some-svc", 9999)
 			So(didFetchState, ShouldBeTrue)
+			So(ring, ShouldNotBeNil)
+			So(err, ShouldBeNil)
 
-			httpmock.Deactivate()
+			httpmock.DeactivateAndReset()
+		})
+
+		Convey("Returns an error on URL failure", func() {
+			httpmock.Activate()
+			httpmock.RegisterResponder(
+				"GET", "http://localhost:7777/api/state.json",
+				func(req *http.Request) (*http.Response, error) {
+					return httpmock.NewStringResponse(500, "OMG it's broken"), nil
+				},
+			)
+
+			ring, err := NewSidecarRing("http://localhost:7777/api/state.json", "some-svc", 9999)
+			So(ring, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+
+			httpmock.DeactivateAndReset()
 		})
 
 		Reset(func() {

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -127,6 +127,28 @@ func Test_onUpdate(t *testing.T) {
 			So(node, ShouldEqual, "")
 		})
 
+		Convey("does not include hosts that are not ALIVE", func() {
+			ring.onUpdate(state)
+			So(len(ring.nodes), ShouldEqual, 1)
+
+			svc2 := service.Service{
+				ID:       "abbaabbaabba",
+				Name:     svcName,
+				Image:    "101deadbeef",
+				Hostname: "some-host",
+				Status:   service.UNHEALTHY,
+				Ports:    []service.Port{{Port: 12345, ServicePort: 9999,  IP: "127.0.0.1"}},
+			}
+			state.AddServiceEntry(svc2)
+
+			ring.onUpdate(state)
+			So(len(ring.nodes), ShouldEqual, 1)
+
+			node, err := ring.manager.GetNode("anything")
+			So(err, ShouldBeNil)
+			So(node, ShouldEqual, "127.0.0.1:23423")
+		})
+
 		Reset(func() {
 			ring.Shutdown()
 		})

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -1,0 +1,143 @@
+package ringman
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Nitro/sidecar/catalog"
+	"github.com/Nitro/sidecar/service"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_NewSidecarRing(t *testing.T) {
+	Convey("NewSidecarRing()", t, func() {
+		ring := NewSidecarRing("127.0.0.1", "some-svc", 9999)
+
+		Convey("Returns a properly configured struct", func() {
+			So(ring.Manager, ShouldNotBeNil)
+			So(ring.managerLooper, ShouldNotBeNil)
+			So(ring.svcName, ShouldEqual, "some-svc")
+			So(ring.svcPort, ShouldEqual, 9999)
+		})
+
+		Reset(func() {
+			ring.Shutdown()
+		})
+	})
+}
+
+func Test_HttpMux(t *testing.T) {
+	Convey("HttpMux()", t, func() {
+		ring := NewSidecarRing("127.0.0.1", "some-svc", 9999)
+
+		Convey("Returns a valid Mux", func() {
+			So(ring.HttpMux(), ShouldNotBeNil)
+		})
+	})
+}
+
+func Test_onUpdate(t *testing.T) {
+	Convey("onUpdate()", t, func() {
+		svcName := "some-svc"
+
+		ring := NewSidecarRing("127.0.0.1", svcName, 9999)
+		state := catalog.NewServicesState()
+
+		svc := service.Service{
+			ID:       "deadbeef123",
+			Name:     svcName,
+			Image:    "101deadbeef",
+			Hostname: "some-host",
+			Status:   service.ALIVE,
+			Ports:    []service.Port{{Port: 23423, ServicePort: 9999, IP: "127.0.0.1"}},
+		}
+
+		state.AddServiceEntry(svc)
+
+		Convey("adds new nodes to the ring", func() {
+			So(len(ring.nodes), ShouldEqual, 0)
+			ring.onUpdate(state)
+			So(len(ring.nodes), ShouldEqual, 1)
+
+			node, err := ring.Manager.GetNode("anything")
+			So(err, ShouldBeNil)
+			So(node, ShouldEqual, "127.0.0.1:23423")
+		})
+
+		Convey("removes old nodes to the ring", func() {
+			svc2 := service.Service{
+				ID:       "abbaabbaabba",
+				Name:     svcName,
+				Image:    "101deadbeef",
+				Hostname: "some-host",
+				Status:   service.ALIVE,
+				Ports:    []service.Port{{Port: 12345, ServicePort: 9999}},
+			}
+			state.AddServiceEntry(svc2)
+
+			ring.onUpdate(state)
+			So(len(ring.nodes), ShouldEqual, 2)
+			ring.onUpdate(catalog.NewServicesState())
+			So(len(ring.nodes), ShouldEqual, 0)
+
+			node, err := ring.Manager.GetNode("anything")
+			So(err.Error(), ShouldContainSubstring, "No nodes in ring")
+			So(node, ShouldEqual, "")
+		})
+
+		Reset(func() {
+			ring.Shutdown()
+		})
+	})
+}
+
+func Test_SidecarHttpGetNodeHandler(t *testing.T) {
+	Convey("SidecarHttpGetNodeHandler()", t, func() {
+		ring := NewSidecarRing("127.0.0.1:7777", "some-svc", 31337)
+
+		req := httptest.NewRequest("GET", "/services/boccacio.json", nil)
+		recorder := httptest.NewRecorder()
+
+		state := catalog.NewServicesState()
+
+		svc := service.Service{
+			ID:       "deadbeef123",
+			Name:     "some-svc",
+			Image:    "101deadbeef",
+			Hostname: "some-host",
+			Status:   service.ALIVE,
+			Ports:    []service.Port{{Port: 23423, ServicePort: 31337, IP: "127.0.0.1"}},
+		}
+
+		state.AddServiceEntry(svc)
+
+		ring.onUpdate(state)
+
+		Convey("returns a 404 when no key is provided", func() {
+			ring.HttpGetNodeHandler(recorder, req)
+
+			So(recorder.Result().StatusCode, ShouldEqual, 404)
+		})
+
+		Convey("returns a node when a key is provided", func() {
+			form := url.Values{}
+			form.Set("key", "bocaccio")
+			req.Form = form
+
+			ring.HttpGetNodeHandler(recorder, req)
+
+			bodyBytes, _ := ioutil.ReadAll(recorder.Result().Body)
+			body := string(bodyBytes)
+
+			So(recorder.Result().StatusCode, ShouldEqual, 200)
+			So(body, ShouldContainSubstring, `"Key": "bocaccio"`)
+			So(body, ShouldContainSubstring, `"Node": "127.0.0.1:23423"`)
+		})
+
+		Reset(func() {
+			ring.Shutdown()
+		})
+	})
+}

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -18,7 +18,7 @@ func Test_NewSidecarRing(t *testing.T) {
 		ring, _ := NewSidecarRing("", "some-svc", 9999)
 
 		Convey("Returns a properly configured struct", func() {
-			So(ring.Manager, ShouldNotBeNil)
+			So(ring.manager, ShouldNotBeNil)
 			So(ring.managerLooper, ShouldNotBeNil)
 			So(ring.svcName, ShouldEqual, "some-svc")
 			So(ring.svcPort, ShouldEqual, 9999)
@@ -101,7 +101,7 @@ func Test_onUpdate(t *testing.T) {
 			ring.onUpdate(state)
 			So(len(ring.nodes), ShouldEqual, 1)
 
-			node, err := ring.Manager.GetNode("anything")
+			node, err := ring.manager.GetNode("anything")
 			So(err, ShouldBeNil)
 			So(node, ShouldEqual, "127.0.0.1:23423")
 		})
@@ -122,7 +122,7 @@ func Test_onUpdate(t *testing.T) {
 			ring.onUpdate(catalog.NewServicesState())
 			So(len(ring.nodes), ShouldEqual, 0)
 
-			node, err := ring.Manager.GetNode("anything")
+			node, err := ring.manager.GetNode("anything")
 			So(err.Error(), ShouldContainSubstring, "No nodes in ring")
 			So(node, ShouldEqual, "")
 		})


### PR DESCRIPTION
This is an alternate ring implementation that is backed by Sidecar service discovery platform instead of a direct use of Memberlist. In platforms where Sidecar is in use, this gets away from requiring a direct cluster entirely.