### PR TITLE
Ensure both type implements the interface Ring and fix tests executions

### DIFF
--- a/hashring_test.go
+++ b/hashring_test.go
@@ -110,13 +110,3 @@ func Test_Commands(t *testing.T) {
 		})
 	})
 }
-
-func Test_Ring(t *testing.T) {
-	Convey("SidecarRing and MemberlistRing implement Ring", t, func() {
-		var ring Ring
-
-		So(func() { ring = &MemberlistRing{} }, ShouldNotPanic)
-		So(func() { ring = &SidecarRing{} }, ShouldNotPanic)
-	})
-
-}

--- a/memberlist.go
+++ b/memberlist.go
@@ -21,6 +21,9 @@ type MemberlistRing struct {
 	managerLooper director.Looper
 }
 
+// Ensure MemberlistRing implements Ring interface
+var _ Ring = (*MemberlistRing)(nil)
+
 // NewDefaultMemberlistRing returns a MemberlistRing configured using the
 // DefaultLANConfig from the memberlist documentation. clusterSeeds must be 0 or
 // more hosts to seed the cluster with. Note that the ring will be _running_

--- a/sidecar.go
+++ b/sidecar.go
@@ -33,6 +33,9 @@ type SidecarRing struct {
 	nodes         map[string]struct{} // Tracking which nodes we already know about
 }
 
+// Ensure SidecarRing implements Ring interface
+var _ Ring = (*SidecarRing)(nil)
+
 // NewSidecarRing returns a properly configured SidecarRing that will filter
 // incoming changes by the service name provided and will only watch the
 // ServicePort number passed in. If the SidecarUrl is not empty string,


### PR DESCRIPTION
This changes contains the following:
- It use the following [go trick](https://splice.com/blog/golang-verify-type-implements-interface-compile-time/) to explicit the implementation of the `Ring` interface by relying on the go compiler

As  result `go test -v` execution is successful again, yay!